### PR TITLE
Fix api handler args passing

### DIFF
--- a/src/http.js
+++ b/src/http.js
@@ -14,7 +14,7 @@ function init(server, routes) {
 
       server.post(`/api/${iface}/${method}`, async (request) => {
         const { query, body, headers } = request;
-        const response = await handler({ ...query, ...body, headers });
+        const response = await handler({ query, body, headers });
         return response;
       });
     }


### PR DESCRIPTION
It seems like it dorsn't make sense to destruct `query` and `body` when passing them to an API route handler